### PR TITLE
Corrections and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features
 * Converts pokernow.club csv files to Pokerstars hand history file text format
 
 ### Known Limitations
+* Only cash games and no tournaments are yet supported
 * Player names containing parantheses '(' or ')' are not supported without mapping in name-mappings.properties
 
 Quick Start

--- a/conversion.properties
+++ b/conversion.properties
@@ -11,7 +11,7 @@ yourUniqueName = yourUniqueName
 # Which of the supported game types are converted, true ones get converted false ones are skipped
 convertOmahaHiHands = true
 convertOmahaHiLoHands = true
-convertTexasHands = false
+convertTexasHands = true
 
 # Amount factor of reduction of bet sizes, can be used to support Hold'em Manager Micro Stakes
 # An example would be converting a pokernow 0.5 / 1 Blind game to $0.05/$0.1 by using 10 instead of 1 here

--- a/src/main/java/ch/evolutionsoft/poker/pokernow/PokernowConstants.java
+++ b/src/main/java/ch/evolutionsoft/poker/pokernow/PokernowConstants.java
@@ -27,7 +27,8 @@ public final class PokernowConstants {
   
   public static final String BUTTON_PREFIX = "dealer: ";
   public static final int BUTTON_PREFIX_LENGTH = BUTTON_PREFIX.length();
-  
+
+  public static final String ANTE_PREFIX = " posts an ante of ";
   public static final String SMALL_BLIND_PREFIX = " posts a small blind of ";
   public static final String BIG_BLIND_PREFIX = " posts a big blind of ";
   public static final String STRADDLE_PREFIX = " posts a straddle of";

--- a/src/main/java/ch/evolutionsoft/poker/pokernow/PokerstarsConstants.java
+++ b/src/main/java/ch/evolutionsoft/poker/pokernow/PokerstarsConstants.java
@@ -22,6 +22,7 @@ public final class PokerstarsConstants {
   
   public static final String POKER_STARS_HAND = "PokerStars Hand #";
 
+  public static final String DEALT_TO_HERO = "Dealt to ";
   public static final String FOLDS = " folds";
   public static final String CHECKS = " checks";
   public static final String CALLS = " calls ";


### PR DESCRIPTION
### Hints
You can checkout and build this branch state with "mvn clean package". I've attached my local build of this branch state too.
This should fix and improve Issues with players containing dots in their names, should support Antes and treat the hero hole cards corrctly. I've got no possibility to check the end import results for Hold'em hands. PockerTracker could import your csv from Issue #8 without errors beside the unsupported game type.

It would be good to check the results on your side with this version.

### Commit/Push
* Fix Issue #7 support player names with dots without mapping
* Support for antes according to Issue #8
* Fix Issue #9 Improve own "hero" hole cards treatment with "dealt to"
instead of additional, most often incorrect, showdown action

[handhistory-converter-0.2.2-SNAPSHOT-program.zip](https://github.com/evolutionsoftswiss/pokernow-handhistory-converter/files/7402517/handhistory-converter-0.2.2-SNAPSHOT-program.zip)